### PR TITLE
Add related thread summaries to context assembler

### DIFF
--- a/src/metamemory/context/index.ts
+++ b/src/metamemory/context/index.ts
@@ -127,6 +127,24 @@ export class ContextAssembler {
         content: `Summary of earlier discussion:\n${thread.summary}`
       } as ResponseInputItem);
     }
+
+    // Add summaries of related threads
+    const relatedThreads = this.threadManager.getRelatedThreads(thread.name);
+    if (relatedThreads.length > 0) {
+      let relatedText = 'Related topic summaries:\n';
+      for (const rel of relatedThreads) {
+        if (rel.summary) {
+          relatedText += `Topic: ${rel.name}\nSummary: ${rel.summary}\n`;
+        }
+      }
+      if (relatedText.trim() !== 'Related topic summaries:') {
+        items.push({
+          type: 'message',
+          role: 'system',
+          content: relatedText.trimEnd()
+        } as ResponseInputItem);
+      }
+    }
     
     // Add recent messages from the thread
     const recentMessages = this.threadManager.getRecentMessages(thread, recentMessageCount);


### PR DESCRIPTION
## Summary
- update `ContextAssembler` to include summaries of related threads for each active topic
- test that context assembler retrieves related threads and includes their summaries

## Testing
- `npm test` *(fails: enters watch mode but all 72 tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6869ae1e7abc832aa6b359bec18e3da7